### PR TITLE
use es6 modules

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,2 @@
-const VueOnline = require('./src/VueOnline.js')
-const OfflineIndicator = require('./src/components/OfflineIndicator.vue')
-module.exports = { OfflineIndicator: OfflineIndicator, VueOnline: VueOnline }
+export { default as VueOnline } from './src/VueOnline.js'
+export { OfflineIndicator } from './src/components/OfflineIndicator.vue'

--- a/src/VueOnline.js
+++ b/src/VueOnline.js
@@ -1,6 +1,7 @@
+import Vue from "vue"
+var main;
 (function() {
-  const Vue = require('vue')
-  const main = new Vue({
+  main = new Vue({
     data: function () {
       return {
         isOnline: true
@@ -27,5 +28,5 @@
   window.addEventListener('online', main.updateStatus)
   window.addEventListener('offline', main.updateStatus)
 
-  module.exports = main
 })()
+export default main


### PR DESCRIPTION
use es6 modules instead of AMD for compatibility with webpack2/babel.
requires building step with babel.
Addresses #4.
May break existing setups.